### PR TITLE
Fix GHC repository

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.5
 
-RUN echo "http://nl.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories
+RUN echo "http://nl.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories
 
 RUN apk add --no-cache \
     gmp \


### PR DESCRIPTION
GHCおよびCabalのリポジトリが
edge/testingからedge/communityに変わっていたので修正。